### PR TITLE
Make the module translatable

### DIFF
--- a/code/extensions/CarouselPage.php
+++ b/code/extensions/CarouselPage.php
@@ -26,7 +26,7 @@ class CarouselPage extends DataExtension {
 		if($this->owner->ShowCarousel) {
 			// Create Add Image Button
 			$add_button = new GridFieldAddNewButton('toolbar-header-left');
-			$add_button->setButtonName('Add Image');
+			$add_button->setButtonName(_t('CarouselPage.ADDIMAGE','Add Image'));
 
 			// Add Carousel Editor
 			$grid_config = GridFieldConfig_RecordEditor::create()
@@ -38,7 +38,7 @@ class CarouselPage extends DataExtension {
 			$carousel_table = GridField::create('CarouselElements', false, $this->owner->CarouselElements()->sort('Sort ASC'), $grid_config);
 
 			// Creates a tab on CMS to manage Carousel on
-			$fields->addFieldToTab('Root.Carousel', $carousel_table);
+			$fields->addFieldToTab('Root.'._t('CarouselPage.CAROUSELTABLABEL', 'Carousel'), $carousel_table);
 		} else {
 			$fields->removeByName('CarouselElements');
 		}
@@ -55,20 +55,20 @@ class CarouselPage extends DataExtension {
 	public function updateSettingsFields(FieldList $fields) {
 		
 		// Produce following message by default
-		$message = '<p>Display carousel on this page</p>';
+		$message = '<p>'._t('CarouselPage.DISPLAYCAROUSELONTHISPAGE', 'Display carousel on this page').'</p>';
 		$fields->addFieldToTab('Root.Settings', LiteralField::create("CarouselMessage", $message));
 
 		// Display option to request carousel on settings tab
 		$carousel = FieldGroup::create(
-			CheckboxField::create('ShowCarousel', 'Add carousel to this page?')
-		)->setTitle('Carousel');
+			CheckboxField::create('ShowCarousel', _t('CarouselPage.ADDCAROUSEL','Add carousel to this page?'))
+		)->setTitle(_t('CarouselPage.TITLE','Carousel'));
 
 		$fields->addFieldToTab('Root.Settings', $carousel);
 
 		// If user selects to add carousel add additional settings
 		if($this->owner->ShowCarousel) {
-			$fields->addFieldToTab('Root.Settings', NumericField::create('CarouselWidth', 'Width'));
-			$fields->addFieldToTab('Root.Settings', NumericField::create('CarouselHeight', 'Height'));
+			$fields->addFieldToTab('Root.Settings', NumericField::create('CarouselWidth', _t('CarouselPage.WIDTH','Width')));
+			$fields->addFieldToTab('Root.Settings', NumericField::create('CarouselHeight', _t('CarouselPage.HEIGHT','Height')));
 		}
 	}
 

--- a/code/model/CarouselImage.php
+++ b/code/model/CarouselImage.php
@@ -22,12 +22,21 @@ class CarouselImage extends DataObject {
 		'Caption' => 'Caption'
 	);
 
-	private static $field_labels = array(
-		'LinkTargetBlank' => 'Open the link in a new tab?'
-	);
-
 	// Default Sort Setting
 	private static $default_sort = "Sort ASC";
+
+	public function fieldLabels($include_relations=true)
+	{
+		$labels = array(
+			'Caption' => _t('CarouselImage.CAPTION', 'Caption'),
+			'Sort' => _t('CarouselImage.SORT', 'Sort'),
+			'Link' => _t('CarouselImage.LINK', 'Link'),
+			'LinkTargetBlank' => _t('CarouselImage.LINKTARGETBLANK', 'Open the link in a new tab?'),
+			'Image' => _t('CarouselImage.IMAGE', 'Image'),
+		);
+		if (!$include_relations) unset($labels['Image']);
+		return $labels;
+	}
 
 	// Get image size according to settings tab information
 	public function getSizedImage() {
@@ -46,7 +55,7 @@ class CarouselImage extends DataObject {
 		$fields = parent::getCMSFields();
 
 		$fields->removeByName('ParentID');
-		$fields->dataFieldByName('Link')->setAttribute('placeholder', 'http://')->setDescription('If empty, clicking the image does nothing. You can use absolute or canonical URLs here.');
+		$fields->dataFieldByName('Link')->setAttribute('placeholder', 'http://')->setDescription(_t('CarouselImage.LINKDESCRIPTION','If empty, clicking the image does nothing. You can use absolute or canonical URLs here.'));
 
 		return $fields;
 	}
@@ -55,7 +64,7 @@ class CarouselImage extends DataObject {
 		if($this->Image()) {
 			return $this->Image()->CMSThumbnail();
 		} else {
-			return '(No Image)';
+			return _t('CarouselImage.NOIMAGE','(No Image)');
 		}
 	}
 }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,0 +1,21 @@
+en:
+  CarouselImage:
+    CAPTION: Caption
+    IMAGE: Image
+    LINK: Link
+    LINKDESCRIPTION: 'If empty, clicking the image does nothing. You can use absolute or canonical URLs here.'
+    LINKTARGETBLANK: 'Open the link in a new tab?'
+    NOIMAGE: '(No Image)'
+    PLURALNAME: 'Carousel Images'
+    SINGULARNAME: 'Carousel Image'
+    SORT: Sort
+  CarouselPage:
+    ADDCAROUSEL: 'Add carousel to this page?'
+    ADDIMAGE: 'Add Image'
+    CAROUSELTABLABEL: Carousel
+    DISPLAYCAROUSELONTHISPAGE: 'Display carousel on this page'
+    HEIGHT: Height
+    NEXT: Next
+    PREVIOUS: Previous
+    TITLE: Carousel
+    WIDTH: Width

--- a/lang/fi.yml
+++ b/lang/fi.yml
@@ -1,0 +1,21 @@
+fi:
+  CarouselImage:
+    CAPTION: Kuvateksti
+    IMAGE: Kuva
+    LINK: Linkki
+    LINKDESCRIPTION: 'Jos tyhjä, kuvan klikkaaminen ei tee mitään. Voit käyttää suhteellisia tai absoluuttisia URL-osoitteita.'
+    LINKTARGETBLANK: 'Avaa linkki uudessa välilehdessä'
+    NOIMAGE: '(Ei kuvaa)'
+    PLURALNAME: 'Karusellin Kuvat'
+    SINGULARNAME: 'Karusellikuva'
+    SORT: Järjestys
+  CarouselPage:
+    ADDCAROUSEL: 'Käytä karusellia tällä sivulla'
+    ADDIMAGE: 'Lisää Kuva'
+    CAROUSELTABLABEL: Karuselli
+    DISPLAYCAROUSELONTHISPAGE: 'Näytä karuselli tällä sivulla'
+    HEIGHT: Korkeus
+    NEXT: Seuraava
+    PREVIOUS: Edellinen
+    TITLE: Karuselli
+    WIDTH: Leveys

--- a/templates/Includes/CarouselImages.ss
+++ b/templates/Includes/CarouselImages.ss
@@ -23,11 +23,11 @@
 			</div>
 			<a class="left carousel-control" href="#carousel" role="button" data-slide="prev">
 			    <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-			    <span class="sr-only">Previous</span>
+			    <span class="sr-only"><%t CarouselPage.PREVIOUS 'Previous' %></span>
 			  </a>
 			  <a class="right carousel-control" href="#carousel" role="button" data-slide="next">
 			    <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-			    <span class="sr-only">Next</span>
+			    <span class="sr-only"><%t CarouselPage.NEXT 'Next' %></span>
 			  </a>
 		</div>
 	</section>


### PR DESCRIPTION
Also add a Finnish translation. One field is still left untranslated (I don't know why, tried to hunt down the reason): the 'Image' field in the Carousel tab of the CarouselPage is always in English, but it's not a big deal as the column is very self-explanatory. Can perhaps be fixed at some point :). I hope that this covers everything else though :).